### PR TITLE
Fix/remove slack notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,3 @@ jobs:
           PY_COLORS: '1'
           ANSIBLE_FORCE_COLOR: '1'
 
-      - name: Slack notification
-        if: always()  # failure()
-        uses: 8398a7/action-slack@v3
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          fields: repo,commit,action,eventName,ref,workflow  # all
-          mention: "channel"
-          if_mention: "failure"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,13 +44,3 @@ jobs:
           draft: false
           prerelease: false
 
-      - name: Slack notification
-        if: always()  # failure()
-        uses: 8398a7/action-slack@v3
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        with:
-          status: ${{ job.status }}
-          fields: repo,commit,action,eventName,ref,workflow  # all
-          mention: "channel"
-          if_mention: "failure"


### PR DESCRIPTION
I've installed the GitHub app for Slack which provides a more streamlined experience for receiving slack notifications on GitHub events